### PR TITLE
Force HTTP 2

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -119,6 +119,10 @@ func New(opts ...Option) *Client {
 	}
 
 	transport := &http.Transport{
+		// Force HTTP/2 negotiation over ALPN. Setting a custom TLSClientConfig
+		// otherwise disables Go's automatic HTTP/2 upgrade, so this flag is
+		// required to keep HTTP/2 enabled.
+		ForceAttemptHTTP2: true,
 		TLSClientConfig: &tls.Config{
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: !options.VerifyTLS, //nolint:gosec // configurable by caller


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single transport flag with documented Go behavior; no TLS policy or API changes beyond protocol negotiation.
> 
> **Overview**
> Sets **`ForceAttemptHTTP2: true`** on the shared `http.Transport` built in `httpclient.New`.
> 
> Because the client already sets a custom `TLSClientConfig` (min TLS 1.2 and optional cert verification), Go stops auto-upgrading to HTTP/2; this change restores ALPN-based HTTP/2 for all callers of `httpclient.New` without changing the public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 706e9fd47b06bcdc16f9bd7b30ffd0bfaf6613b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->